### PR TITLE
[cmake] Clean some useless cmake instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(BUILD_SHARED_LIBS "Build STBIPP as shared Library" ON)
 option(STBIPP_BUILD_EXAMPLE "Build STBIPP examples" ON)
-option(STBIPP_INSTALL "Enable if you wish to perform an install / Disable to use the lib as third party" OFF)
 
 include(FetchContent)
 include(CMakePackageConfigHelpers)
@@ -83,53 +82,50 @@ endif()
 
 ################################### Install/Packaging ##############################
 
-if(${STBIPP_INSTALL})
+set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/cmake/${PROJECT_NAME}")
+set(STBIPP_ROOT_DIR ${CMAKE_INSTALL_PREFIX})
+set(TARGETS_EXPORT_NAME ${PROJECT_NAME}Target)
 
-    set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/cmake/${PROJECT_NAME}")
-    set(STBIPP_ROOT_DIR ${CMAKE_INSTALL_PREFIX})
-    set(TARGETS_EXPORT_NAME ${PROJECT_NAME}Target)
-
-    install(
-        TARGETS
-        ${PROJECT_NAME}
-        EXPORT ${TARGETS_EXPORT_NAME}
-        CONFIGURATIONS ${CMAKE_BUILD_TYPE}
-        )
-    install(EXPORT ${PROJECT_NAME}Target NAMESPACE Stbipp:: DESTINATION ${CONFIG_INSTALL_DIR})
+install(
+    TARGETS
+    ${PROJECT_NAME}
+    EXPORT ${TARGETS_EXPORT_NAME}
+    CONFIGURATIONS ${CMAKE_BUILD_TYPE}
+    )
+install(EXPORT ${PROJECT_NAME}Target NAMESPACE Stbipp:: DESTINATION ${CONFIG_INSTALL_DIR})
 
 
-    configure_package_config_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/StbippConfig.cmake.in
-        ${CMAKE_CURRENT_BINARY_DIR}/StbippConfig.cmake
-        INSTALL_DESTINATION ${CONFIG_INSTALL_DIR}
-        )
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/StbippConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/StbippConfig.cmake
+    INSTALL_DESTINATION ${CONFIG_INSTALL_DIR}
+    )
 
-    write_basic_package_version_file(
-        ${CMAKE_CURRENT_BINARY_DIR}/cmake/StbippConfigVersion.cmake
-        COMPATIBILITY ExactVersion
-        )
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/StbippConfigVersion.cmake
+    COMPATIBILITY ExactVersion
+    )
 
-    install(
-        DIRECTORY
-        src/stbipp
-        DESTINATION
-        ${INCLUDE_INSTALL_DIR}
-        FILES_MATCHING PATTERN "*.hpp"
-        )
+install(
+    DIRECTORY
+    src/stbipp
+    DESTINATION
+    ${INCLUDE_INSTALL_DIR}
+    FILES_MATCHING PATTERN "*.hpp"
+    )
 
-    install(
-        FILES
-        ${GENERATED_DIR}/StbippSymbols.h
-        DESTINATION
-        ${STBIPP_INCLUDE_DIR}
-        )
-    install(
-        FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/StbippConfig.cmake
-        ${CMAKE_CURRENT_BINARY_DIR}/cmake/StbippConfigVersion.cmake
-        DESTINATION ${CONFIG_INSTALL_DIR}
-        )
-endif()
+install(
+    FILES
+    ${GENERATED_DIR}/StbippSymbols.h
+    DESTINATION
+    ${STBIPP_INCLUDE_DIR}
+    )
+install(
+    FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/StbippConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/StbippConfigVersion.cmake
+    DESTINATION ${CONFIG_INSTALL_DIR}
+    )
 
 
 ################################### Example ##############################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 
-option(STBIPP_SHARED "Build STBIPP as shared Library" ON)
+option(BUILD_SHARED_LIBS "Build STBIPP as shared Library" ON)
 option(STBIPP_BUILD_EXAMPLE "Build STBIPP examples" ON)
 option(STBIPP_INSTALL "Enable if you wish to perform an install / Disable to use the lib as third party" OFF)
 
@@ -56,11 +56,7 @@ set(STBIPP_HEADERS
 set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/include)
 set(STBIPP_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include/stbipp)
 
-if(${STBIPP_SHARED})
-    add_library(${PROJECT_NAME} SHARED ${STBIPP_SOURCES} ${STBIPP_HEADERS})
-else()
-    add_library(${PROJECT_NAME} STATIC ${STBIPP_SOURCES} ${STBIPP_HEADERS})
-endif()
+add_library(${PROJECT_NAME} ${STBIPP_SOURCES} ${STBIPP_HEADERS})
 
 
 generate_export_header(${PROJECT_NAME}
@@ -77,7 +73,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     )
 
 
-if(NOT ${STBIPP_SHARED})
+if(NOT ${BUILD_SHARED_LIBS})
     set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS -DSTBIPP_STATIC_DEFINE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,11 +73,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 
 if(NOT ${BUILD_SHARED_LIBS})
-    set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS -DSTBIPP_STATIC_DEFINE)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC STBIPP_STATIC_DEFINE)
 endif()
 
 if(${CMAKE_BUILD_TYPE} MATCHES Debug)
-    set_property(TARGET ${PROJECT_NAME} PROPERTY DEBUG_POSTFIX "d")
+    set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "d")
 endif()
 
 ################################### Install/Packaging ##############################


### PR DESCRIPTION
We remove the useless variables : 

- `STBIPP_SHARED` replaced by `BUILD_SHARED_LIBS`
- `STBIPP_INSTALL` removed
- Export the static symbols when installing the lib in static mode