### PR TITLE
[Color] Add single value operations for multiplication, division, ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features:
 
 Refactor:
 - Move template function implementation in a separate file (see #20)
+- Change the CMake package compatibility strategy from 'ExactVersion' to 'SameMajorVersion'
 
 Fix:
 - Fix the save function in the ImageExporter when saving an image in a non hdr format, with channel value greater than 1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Features:
 
 Refactor:
 - Move template function implementation in a separate file (see #20)
-- Change the CMake package compatibility strategy from 'ExactVersion' to 'SameMajorVersion'
+- Change the CMake package compatibility strategy from `ExactVersion` to `SameMajorVersion`
 
 Fix:
 - Fix the save function in the ImageExporter when saving an image in a non hdr format, with channel value greater than 1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Features:
 - Add color channel iterators (iterator, const_iterator, reverse_iterator, const_reverse_iterator)
+- Add color binary operation with single float or integral value (see #17)
 
 Refactor:
 - Move template function implementation in a separate file (see #20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ configure_package_config_file(
 
 write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/StbippConfigVersion.cmake
-    COMPATIBILITY ExactVersion
+    COMPATIBILITY SameMajorVersion
     )
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,9 @@ install(
     src/stbipp
     DESTINATION
     ${INCLUDE_INSTALL_DIR}
-    FILES_MATCHING PATTERN "*.hpp"
+    FILES_MATCHING 
+    PATTERN "*.hpp" 
+    PATTERN "*.inl"
     )
 
 install(

--- a/src/stbipp/Color.hpp
+++ b/src/stbipp/Color.hpp
@@ -36,6 +36,12 @@ struct is_data_type_compatible
 
 namespace stbipp
 {
+/**
+ * @brief Color class works like a classic mathematical vector with basic arithmetic operations
+ *
+ * @tparam DataType Type used to store individual elements
+ * @tparam channels Number of channels for the color
+ */
 template<class DataType, unsigned int channels>
 class Color
 {
@@ -335,12 +341,34 @@ class Color
     Color& operator+=(const Color<ODataType, oDataSize>& other);
 
     /**
-     * @brief Add the content of other to this as an immutable object
+     * @brief Add the content of val to all channels of this
+     *
+     * @tparam Real val type
+     * @param[in] val Value to be added
+     *
+     * @return A reference to this
+     */
+    template<class Real>
+    typename std::enable_if<is_data_type_compatible<Real>::value, Color>::type& operator+=(Real val);
+
+    /**
+     * @brief Add the content of other to this in a new object
      * @param[in] other The color to add
      * @return The addition of this and other
      */
     template<class ODataType, unsigned int oDataSize>
     Color operator+(const Color<ODataType, oDataSize>& other) const;
+
+    /**
+     * @brief Add the content of val to all channels of this in a new object
+     *
+     * @tparam Real val type
+     * @param[in] val Value to be added
+     *
+     * @return The addition of this and val
+     */
+    template<class Real>
+    typename std::enable_if<is_data_type_compatible<Real>::value, Color>::type operator+(Real val) const;
 
     /**
      * @brief Substract the content of this by other
@@ -351,12 +379,34 @@ class Color
     Color& operator-=(const Color<ODataType, oDataSize>& other);
 
     /**
-     * @brief Substract the content of this by other as an immutable object
+     * @brief Substract the content of val to all channels of this
+     *
+     * @tparam Real val type
+     * @param[in] val Value to be substracted
+     *
+     * @return A reference to this
+     */
+    template<class Real>
+    typename std::enable_if<is_data_type_compatible<Real>::value, Color>::type& operator-=(Real val);
+
+    /**
+     * @brief Substract the content of this by other in a new object
      * @param[in] other The color to substract
      * @return The substraction of this by other
      */
     template<class ODataType, unsigned int oDataSize>
     Color operator-(const Color<ODataType, oDataSize>& other) const;
+
+    /**
+     * @brief Substract the content of val to all channels of this in a new object
+     *
+     * @tparam Real val type
+     * @param[in] val Value to be substracted
+     *
+     * @return The substraction of this and val
+     */
+    template<class Real>
+    typename std::enable_if<is_data_type_compatible<Real>::value, Color>::type operator-(Real val) const;
 
     /**
      * @brief Negate the content of this
@@ -373,12 +423,34 @@ class Color
     Color& operator*=(const Color<ODataType, oDataSize>& other);
 
     /**
-     * @brief Multiply the content of this by other as an immutable object
+     * @brief Multiply the content of val to all channels of this
+     *
+     * @tparam Real val type
+     * @param[in] val Value to multiply
+     *
+     * @return A reference to this
+     */
+    template<class Real>
+    typename std::enable_if<is_data_type_compatible<Real>::value, Color>::type& operator*=(Real val);
+
+    /**
+     * @brief Multiply the content of this by other in a new object
      * @param[in] other The color to multiply
      * @return The multiplication of this by other
      */
     template<class ODataType, unsigned int oDataSize>
     Color operator*(const Color<ODataType, oDataSize>& other) const;
+
+    /**
+     * @brief Multiply the content of val to all channels of this in a new object
+     *
+     * @tparam Real val type
+     * @param[in] val Value to multiply
+     *
+     * @return The multiplication of this and val
+     */
+    template<class Real>
+    typename std::enable_if<is_data_type_compatible<Real>::value, Color>::type operator*(Real val) const;
 
     /**
      * @brief Divide the content of this by other
@@ -389,16 +461,51 @@ class Color
     Color& operator/=(const Color<ODataType, oDataSize>& other);
 
     /**
-     * @brief Divide the content of this by other as an immutable object
+     * @brief Divide the content of all channels of this by val
+     *
+     * @tparam Real val type
+     * @param[in] val Value to divide by
+     *
+     * @return A reference to this
+     */
+    template<class Real>
+    typename std::enable_if<is_data_type_compatible<Real>::value, Color>::type& operator/=(Real val);
+
+    /**
+     * @brief Divide the content of this by other in a new object
      * @param[in] other The color to divide
      * @return The division of this by other
      */
     template<class ODataType, unsigned int oDataSize>
     Color operator/(const Color<ODataType, oDataSize>& other) const;
-};
 
+    /**
+     * @brief Divide the content of all channels of this by val in a new object
+     *
+     * @tparam Real val type
+     * @param[in] val Value to divide by
+     *
+     * @return The division of this and val
+     */
+    template<class Real>
+    typename std::enable_if<is_data_type_compatible<Real>::value, Color>::type operator/(Real val) const;
+};
 } // namespace stbipp
+
+template<class DataType, unsigned int channels, class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, stbipp::Color<DataType, channels>>::type operator+(
+  Real val, const stbipp::Color<DataType, channels>& col);
+
+template<class DataType, unsigned int channels, class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, stbipp::Color<DataType, channels>>::type operator-(
+  Real val, const stbipp::Color<DataType, channels>& col);
+
+template<class DataType, unsigned int channels, class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, stbipp::Color<DataType, channels>>::type operator*(
+  Real val, const stbipp::Color<DataType, channels>& col);
+
 #include "stbipp/Color.inl"
+
 namespace stbipp
 {
 using Colorf = Color<float, 1>;

--- a/src/stbipp/Color.hpp
+++ b/src/stbipp/Color.hpp
@@ -341,7 +341,7 @@ class Color
     Color& operator+=(const Color<ODataType, oDataSize>& other);
 
     /**
-     * @brief Add the content of val to all channels of this
+     * @brief Add the content of val to all channels content
      *
      * @tparam Real val type
      * @param[in] val Value to be added
@@ -360,7 +360,7 @@ class Color
     Color operator+(const Color<ODataType, oDataSize>& other) const;
 
     /**
-     * @brief Add the content of val to all channels content of this in a new object
+     * @brief Add the content of val to all channels content in a new object
      *
      * @tparam Real val type
      * @param[in] val Value to be added
@@ -379,7 +379,7 @@ class Color
     Color& operator-=(const Color<ODataType, oDataSize>& other);
 
     /**
-     * @brief Substract the content of val to all channels content of this
+     * @brief Substract the content of val to all channels content
      *
      * @tparam Real val type
      * @param[in] val Value to be substracted
@@ -398,7 +398,7 @@ class Color
     Color operator-(const Color<ODataType, oDataSize>& other) const;
 
     /**
-     * @brief Substract the content of val to all channels of this in a new object
+     * @brief Substract the content of val to all channels in a new object
      *
      * @tparam Real val type
      * @param[in] val Value to be substracted

--- a/src/stbipp/Color.hpp
+++ b/src/stbipp/Color.hpp
@@ -360,7 +360,7 @@ class Color
     Color operator+(const Color<ODataType, oDataSize>& other) const;
 
     /**
-     * @brief Add the content of val to all channels of this in a new object
+     * @brief Add the content of val to all channels content of this in a new object
      *
      * @tparam Real val type
      * @param[in] val Value to be added
@@ -379,7 +379,7 @@ class Color
     Color& operator-=(const Color<ODataType, oDataSize>& other);
 
     /**
-     * @brief Substract the content of val to all channels of this
+     * @brief Substract the content of val to all channels content of this
      *
      * @tparam Real val type
      * @param[in] val Value to be substracted
@@ -423,7 +423,7 @@ class Color
     Color& operator*=(const Color<ODataType, oDataSize>& other);
 
     /**
-     * @brief Multiply the content of val to all channels of this
+     * @brief Multiply the content of val by all channels value
      *
      * @tparam Real val type
      * @param[in] val Value to multiply
@@ -442,7 +442,7 @@ class Color
     Color operator*(const Color<ODataType, oDataSize>& other) const;
 
     /**
-     * @brief Multiply the content of val to all channels of this in a new object
+     * @brief Multiply the content of val by all channels value in a new object
      *
      * @tparam Real val type
      * @param[in] val Value to multiply
@@ -461,7 +461,7 @@ class Color
     Color& operator/=(const Color<ODataType, oDataSize>& other);
 
     /**
-     * @brief Divide the content of all channels of this by val
+     * @brief Divide the content of all channels by val
      *
      * @tparam Real val type
      * @param[in] val Value to divide by
@@ -480,7 +480,7 @@ class Color
     Color operator/(const Color<ODataType, oDataSize>& other) const;
 
     /**
-     * @brief Divide the content of all channels of this by val in a new object
+     * @brief Divide the content of all channels by val in a new object
      *
      * @tparam Real val type
      * @param[in] val Value to divide by

--- a/src/stbipp/Color.inl
+++ b/src/stbipp/Color.inl
@@ -314,6 +314,18 @@ Color<DataType, channels>& Color<DataType, channels>::operator+=(const Color<ODa
 }
 
 template<class DataType, unsigned int channels>
+template<class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, Color<DataType, channels>>::type&
+Color<DataType, channels>::operator+=(Real val)
+{
+    for(auto& channel: m_data)
+    {
+        channel += static_cast<DataType>(val);
+    }
+    return *this;
+}
+
+template<class DataType, unsigned int channels>
 template<class ODataType, unsigned int oDataSize>
 Color<DataType, channels> Color<DataType, channels>::operator+(const Color<ODataType, oDataSize>& other) const
 {
@@ -321,6 +333,15 @@ Color<DataType, channels> Color<DataType, channels>::operator+(const Color<OData
                   "Both colors must be of the same size and type");
     Color temp{*this};
     return temp += other;
+}
+
+template<class DataType, unsigned int channels>
+template<class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, Color<DataType, channels>>::type
+Color<DataType, channels>::operator+(Real val) const
+{
+    Color temp{*this};
+    return temp += val;
 }
 
 template<class DataType, unsigned int channels>
@@ -337,6 +358,18 @@ Color<DataType, channels>& Color<DataType, channels>::operator-=(const Color<ODa
 }
 
 template<class DataType, unsigned int channels>
+template<class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, Color<DataType, channels>>::type&
+Color<DataType, channels>::operator-=(Real val)
+{
+    for(auto& channel: m_data)
+    {
+        channel -= static_cast<DataType>(val);
+    }
+    return *this;
+}
+
+template<class DataType, unsigned int channels>
 template<class ODataType, unsigned int oDataSize>
 Color<DataType, channels> Color<DataType, channels>::operator-(const Color<ODataType, oDataSize>& other) const
 {
@@ -344,6 +377,15 @@ Color<DataType, channels> Color<DataType, channels>::operator-(const Color<OData
                   "Both colors must be of the same size and type");
     Color temp{*this};
     return temp -= other;
+}
+
+template<class DataType, unsigned int channels>
+template<class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, Color<DataType, channels>>::type
+Color<DataType, channels>::operator-(Real val) const
+{
+    Color temp{*this};
+    return temp -= val;
 }
 
 template<class DataType, unsigned int channels>
@@ -365,6 +407,17 @@ Color<DataType, channels>& Color<DataType, channels>::operator*=(const Color<ODa
     }
     return *this;
 }
+template<class DataType, unsigned int channels>
+template<class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, Color<DataType, channels>>::type&
+Color<DataType, channels>::operator*=(Real val)
+{
+    for(auto& channel: m_data)
+    {
+        channel *= val;
+    }
+    return *this;
+}
 
 template<class DataType, unsigned int channels>
 template<class ODataType, unsigned int oDataSize>
@@ -374,6 +427,15 @@ Color<DataType, channels> Color<DataType, channels>::operator*(const Color<OData
                   "Both colors must be of the same size and type");
     Color temp{*this};
     return temp *= other;
+}
+
+template<class DataType, unsigned int channels>
+template<class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, Color<DataType, channels>>::type
+  Color<DataType, channels>::operator*(Real val) const
+{
+    Color temp{*this};
+    return temp *= val;
 }
 
 template<class DataType, unsigned int channels>
@@ -390,6 +452,18 @@ Color<DataType, channels>& Color<DataType, channels>::operator/=(const Color<ODa
 }
 
 template<class DataType, unsigned int channels>
+template<class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, Color<DataType, channels>>::type&
+Color<DataType, channels>::operator/=(Real val)
+{
+    for(auto& channel: m_data)
+    {
+        channel /= val;
+    }
+    return *this;
+}
+
+template<class DataType, unsigned int channels>
 template<class ODataType, unsigned int oDataSize>
 Color<DataType, channels> Color<DataType, channels>::operator/(const Color<ODataType, oDataSize>& other) const
 {
@@ -398,5 +472,35 @@ Color<DataType, channels> Color<DataType, channels>::operator/(const Color<OData
     Color temp{*this};
     return temp /= other;
 }
+
+template<class DataType, unsigned int channels>
+template<class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, Color<DataType, channels>>::type
+Color<DataType, channels>::operator/(Real val) const
+{
+    Color temp{*this};
+    return temp /= val;
+}
 } // namespace stbipp
 
+template<class DataType, unsigned int channels, class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, stbipp::Color<DataType, channels>>::type operator+(
+  Real val, const stbipp::Color<DataType, channels>& col)
+{
+    return col + val;
+}
+
+template<class DataType, unsigned int channels, class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, stbipp::Color<DataType, channels>>::type operator-(
+  Real val, const stbipp::Color<DataType, channels>& col)
+{
+    stbipp::Color<DataType, channels> retCol{val};
+    return retCol - col;
+}
+
+template<class DataType, unsigned int channels, class Real>
+typename std::enable_if<is_data_type_compatible<Real>::value, stbipp::Color<DataType, channels>>::type operator*(
+  Real val, const stbipp::Color<DataType, channels>& col)
+{
+    return col * val;
+}


### PR DESCRIPTION
In this pull request, we add the following new operations:
```cpp
stbipp::Color4f col{};
col += 1; col = col + 1; col = 1 + col;
col -= 1; col = col - 1; col = 1 - col;
col *= 1; col = col * 1; col = 1 * col;
col /= 1; col = col / 1;
```
Features:
- That fix #17
- We also fix the installation of the template implementation files
- Change the cmake package version compatibility from `ExactVersion` to `SameMajorVersion`
